### PR TITLE
Skip empty group while pruning.

### DIFF
--- a/paddleslim/prune/pruner.py
+++ b/paddleslim/prune/pruner.py
@@ -91,6 +91,8 @@ class Pruner():
         pruned_params = []
         for param, ratio in zip(params, ratios):
             group = collect_convs([param], graph, visited)[0]  # [(name, axis)]
+            if group is None or len(group) == 0:
+                continue
             if only_graph and self.idx_selector.__name__ == "default_idx_selector":
 
                 param_v = graph.var(param)


### PR DESCRIPTION
```
python train.py \
--model "ResNet34" \
--criterion "geometry_median" \
--pruned_ratio=0.3125

2020-04-23 16:29:22,737-INFO: FLOPs before pruning: 69854464.0
2020-04-23 16:29:24,723-INFO: FLOPs after pruning: 33773584.0
```