### PR TITLE
add power to quant_embedding dict

### DIFF
--- a/paddleslim/quant/quant_embedding.py
+++ b/paddleslim/quant/quant_embedding.py
@@ -334,6 +334,7 @@ def _quant_embedding_log(graph, scope, place, config, var_name,
 
     # get quantize dict and quanted tensor
     topk_num, quanted_tensor = _quant_log(embedding_tensor, config)
+    topk_num = np.power(2, topk_num)
 
     #create params must use create_persistable_node
     topk_num_var = graph.create_persistable_node(


### PR DESCRIPTION
add power to quant_embedding dict
将dequantize_log时的运算power挪在量化压缩时，以加速模型inference速度。对应paddle pr https://github.com/PaddlePaddle/Paddle/pull/24607