### PR TITLE
slimfacenet.py has a bug, in 337 lines fluid.one_hot is not correct,s…

### DIFF
--- a/demo/models/slimfacenet.py
+++ b/demo/models/slimfacenet.py
@@ -334,7 +334,7 @@ class SlimFaceNet():
         else:
             pass
 
-        one_hot = fluid.one_hot(input=label, depth=out_dim)
+        one_hot = fluid.layers.one_hot(input=label, depth=out_dim)
         output = fluid.layers.elementwise_mul(
             one_hot, phi) + fluid.layers.elementwise_mul(
                 (1.0 - one_hot), cosine)


### PR DESCRIPTION
When slimfacenet is used to train the model, arc_ margin_product has a bug，In lines 377 fluid.one_hot cannot calculate the loss correctly. The right thing to do is fluid.layers .one_ hot。