### PR TITLE
Support for pruning training graph with auxiliary parameters.

### DIFF
--- a/demo/dygraph/pruning/eval.py
+++ b/demo/dygraph/pruning/eval.py
@@ -9,8 +9,8 @@ import functools
 import math
 import time
 import numpy as np
-sys.path[0] = os.path.join(
-    os.path.dirname("__file__"), os.path.pardir, os.path.pardir)
+sys.path.append(
+    os.path.join(os.path.dirname("__file__"), os.path.pardir, os.path.pardir))
 import paddleslim
 from paddleslim.common import get_logger
 from paddleslim.analysis import dygraph_flops as flops

--- a/demo/dygraph/pruning/export_model.py
+++ b/demo/dygraph/pruning/export_model.py
@@ -9,8 +9,8 @@ import functools
 import math
 import time
 import numpy as np
-sys.path[0] = os.path.join(
-    os.path.dirname("__file__"), os.path.pardir, os.path.pardir)
+sys.path.append(
+    os.path.join(os.path.dirname("__file__"), os.path.pardir, os.path.pardir))
 import paddleslim
 from paddleslim.common import get_logger
 import paddle.vision.models as models

--- a/demo/dygraph/pruning/imagenet.py
+++ b/demo/dygraph/pruning/imagenet.py
@@ -34,9 +34,10 @@ class ImageNetDataset(DatasetFolder):
 
         self.samples = []
         list_file = "train_list.txt" if self.mode == "train" else "val_list.txt"
-        with open(os.path.join([path, list_file]), 'r') as f:
+        with open(os.path.join(path, list_file), 'r') as f:
             for line in f:
                 _image, _label = line.strip().split(" ")
+                _image = os.path.join(path, _image)
                 self.samples.append((_image, int(_label)))
         normalize = transforms.Normalize(
             mean=[123.675, 116.28, 103.53], std=[58.395, 57.120, 57.375])

--- a/demo/dygraph/pruning/train.py
+++ b/demo/dygraph/pruning/train.py
@@ -9,8 +9,8 @@ import functools
 import math
 import time
 import numpy as np
-sys.path[0] = os.path.join(
-    os.path.dirname("__file__"), os.path.pardir, os.path.pardir)
+sys.path.append(
+    os.path.join(os.path.dirname("__file__"), os.path.pardir, os.path.pardir))
 import paddleslim
 from paddleslim.common import get_logger
 from paddleslim.analysis import dygraph_flops as flops

--- a/demo/dygraph/quant/mobilenet_v3.py
+++ b/demo/dygraph/quant/mobilenet_v3.py
@@ -63,15 +63,15 @@ class MobileNetV3(nn.Layer):
                 [5, 72, 40, True, "relu", 2],
                 [5, 120, 40, True, "relu", 1],
                 [5, 120, 40, True, "relu", 1],
-                [3, 240, 80, False, "hardswish", 2],
-                [3, 200, 80, False, "hardswish", 1],
-                [3, 184, 80, False, "hardswish", 1],
-                [3, 184, 80, False, "hardswish", 1],
-                [3, 480, 112, True, "hardswish", 1],
-                [3, 672, 112, True, "hardswish", 1],
-                [5, 672, 160, True, "hardswish", 2],
-                [5, 960, 160, True, "hardswish", 1],
-                [5, 960, 160, True, "hardswish", 1],
+                [3, 240, 80, False, "hard_swish", 2],
+                [3, 200, 80, False, "hard_swish", 1],
+                [3, 184, 80, False, "hard_swish", 1],
+                [3, 184, 80, False, "hard_swish", 1],
+                [3, 480, 112, True, "hard_swish", 1],
+                [3, 672, 112, True, "hard_swish", 1],
+                [5, 672, 160, True, "hard_swish", 2],
+                [5, 960, 160, True, "hard_swish", 1],
+                [5, 960, 160, True, "hard_swish", 1],
             ]
             self.cls_ch_squeeze = 960
             self.cls_ch_expand = 1280
@@ -81,14 +81,14 @@ class MobileNetV3(nn.Layer):
                 [3, 16, 16, True, "relu", 2],
                 [3, 72, 24, False, "relu", 2],
                 [3, 88, 24, False, "relu", 1],
-                [5, 96, 40, True, "hardswish", 2],
-                [5, 240, 40, True, "hardswish", 1],
-                [5, 240, 40, True, "hardswish", 1],
-                [5, 120, 48, True, "hardswish", 1],
-                [5, 144, 48, True, "hardswish", 1],
-                [5, 288, 96, True, "hardswish", 2],
-                [5, 576, 96, True, "hardswish", 1],
-                [5, 576, 96, True, "hardswish", 1],
+                [5, 96, 40, True, "hard_swish", 2],
+                [5, 240, 40, True, "hard_swish", 1],
+                [5, 240, 40, True, "hard_swish", 1],
+                [5, 120, 48, True, "hard_swish", 1],
+                [5, 144, 48, True, "hard_swish", 1],
+                [5, 288, 96, True, "hard_swish", 2],
+                [5, 576, 96, True, "hard_swish", 1],
+                [5, 576, 96, True, "hard_swish", 1],
             ]
             self.cls_ch_squeeze = 576
             self.cls_ch_expand = 1280
@@ -104,7 +104,7 @@ class MobileNetV3(nn.Layer):
             padding=1,
             num_groups=1,
             if_act=True,
-            act="hardswish",
+            act="hard_swish",
             name="conv1")
 
         self.block_list = []
@@ -134,7 +134,7 @@ class MobileNetV3(nn.Layer):
             padding=0,
             num_groups=1,
             if_act=True,
-            act="hardswish",
+            act="hard_swish",
             name="conv_last")
 
         self.pool = AdaptiveAvgPool2D(1)

--- a/demo/dygraph/quant/mobilenet_v3.py
+++ b/demo/dygraph/quant/mobilenet_v3.py
@@ -21,7 +21,7 @@ import paddle
 from paddle import ParamAttr
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.nn.functional.activation import hard_sigmoid, hard_swish
+from paddle.nn.functional.activation import hardsigmoid, hardswish
 from paddle.nn import Conv2D, BatchNorm, Linear, Dropout
 from paddle.nn import AdaptiveAvgPool2D, MaxPool2D, AvgPool2D
 from paddle.regularizer import L2Decay
@@ -64,15 +64,15 @@ class MobileNetV3(nn.Layer):
                 [5, 72, 40, True, "relu", 2],
                 [5, 120, 40, True, "relu", 1],
                 [5, 120, 40, True, "relu", 1],
-                [3, 240, 80, False, "hard_swish", 2],
-                [3, 200, 80, False, "hard_swish", 1],
-                [3, 184, 80, False, "hard_swish", 1],
-                [3, 184, 80, False, "hard_swish", 1],
-                [3, 480, 112, True, "hard_swish", 1],
-                [3, 672, 112, True, "hard_swish", 1],
-                [5, 672, 160, True, "hard_swish", 2],
-                [5, 960, 160, True, "hard_swish", 1],
-                [5, 960, 160, True, "hard_swish", 1],
+                [3, 240, 80, False, "hardswish", 2],
+                [3, 200, 80, False, "hardswish", 1],
+                [3, 184, 80, False, "hardswish", 1],
+                [3, 184, 80, False, "hardswish", 1],
+                [3, 480, 112, True, "hardswish", 1],
+                [3, 672, 112, True, "hardswish", 1],
+                [5, 672, 160, True, "hardswish", 2],
+                [5, 960, 160, True, "hardswish", 1],
+                [5, 960, 160, True, "hardswish", 1],
             ]
             self.cls_ch_squeeze = 960
             self.cls_ch_expand = 1280
@@ -82,14 +82,14 @@ class MobileNetV3(nn.Layer):
                 [3, 16, 16, True, "relu", 2],
                 [3, 72, 24, False, "relu", 2],
                 [3, 88, 24, False, "relu", 1],
-                [5, 96, 40, True, "hard_swish", 2],
-                [5, 240, 40, True, "hard_swish", 1],
-                [5, 240, 40, True, "hard_swish", 1],
-                [5, 120, 48, True, "hard_swish", 1],
-                [5, 144, 48, True, "hard_swish", 1],
-                [5, 288, 96, True, "hard_swish", 2],
-                [5, 576, 96, True, "hard_swish", 1],
-                [5, 576, 96, True, "hard_swish", 1],
+                [5, 96, 40, True, "hardswish", 2],
+                [5, 240, 40, True, "hardswish", 1],
+                [5, 240, 40, True, "hardswish", 1],
+                [5, 120, 48, True, "hardswish", 1],
+                [5, 144, 48, True, "hardswish", 1],
+                [5, 288, 96, True, "hardswish", 2],
+                [5, 576, 96, True, "hardswish", 1],
+                [5, 576, 96, True, "hardswish", 1],
             ]
             self.cls_ch_squeeze = 576
             self.cls_ch_expand = 1280
@@ -105,7 +105,7 @@ class MobileNetV3(nn.Layer):
             padding=1,
             num_groups=1,
             if_act=True,
-            act="hard_swish",
+            act="hardswish",
             name="conv1")
 
         self.block_list = []
@@ -135,7 +135,7 @@ class MobileNetV3(nn.Layer):
             padding=0,
             num_groups=1,
             if_act=True,
-            act="hard_swish",
+            act="hardswish",
             name="conv_last")
 
         self.pool = AdaptiveAvgPool2D(1)
@@ -165,7 +165,7 @@ class MobileNetV3(nn.Layer):
         x = self.pool(x)
 
         x = self.last_conv(x)
-        x = hard_swish(x)
+        x = hardswish(x)
         x = paddle.reshape(x, shape=[x.shape[0], x.shape[1]])
         x = self.out(x)
 
@@ -213,8 +213,8 @@ class ConvBNLayer(nn.Layer):
         if self.if_act:
             if self.act == "relu":
                 x = F.relu(x)
-            elif self.act == "hard_swish":
-                x = hard_swish(x)
+            elif self.act == "hardswish":
+                x = hardswish(x)
             else:
                 print("The activation function is selected incorrectly.")
                 exit()
@@ -303,7 +303,7 @@ class SEModule(nn.Layer):
         outputs = self.conv1(outputs)
         outputs = F.relu(outputs)
         outputs = self.conv2(outputs)
-        outputs = hard_sigmoid(outputs)
+        outputs = hardsigmoid(outputs)
         return paddle.multiply(x=inputs, y=outputs)
 
 

--- a/paddleslim/dygraph/fpgm_pruner.py
+++ b/paddleslim/dygraph/fpgm_pruner.py
@@ -20,9 +20,6 @@ class FPGMFilterPruner(FilterPruner):
             if _item['pruned_dims'] == [0]:
                 value = _item['value']
                 pruned_dims = _item['pruned_dims']
-
-        assert (pruned_dims == [0])
-
         dist_sum_list = []
         for out_i in range(value.shape[0]):
             dist_sum = self.get_distance_sum(value, out_i)

--- a/paddleslim/dygraph/pruning_plan.py
+++ b/paddleslim/dygraph/pruning_plan.py
@@ -77,7 +77,8 @@ class PruningPlan():
             for _mask in self._masks[var_name]:
                 if pruning_mask.dims == _mask.dims:
                     _mask.mask = list(
-                        np.array(_mask.mask) | np.array(pruning_mask.mask))
+                        np.array(_mask.mask).astype(np.int64) & np.array(
+                            pruning_mask.mask).astype(np.int64))
         else:
             self._masks[var_name].append(pruning_mask)
             self._dims[var_name].append(pruning_mask.dims)
@@ -171,7 +172,7 @@ class PruningPlan():
                                                       paddle.to_tensor(value))
                             _logger.debug("Backup values of {} into buffers.".
                                           format(param.name))
-                        bool_mask = mask.astype(bool)
+                        bool_mask = np.array(mask).astype(bool)
                         pruned_value = np.apply_along_axis(
                             lambda data: data[bool_mask], dims[0], value)
                         p = t_value._place()

--- a/paddleslim/dygraph/var_group.py
+++ b/paddleslim/dygraph/var_group.py
@@ -44,12 +44,9 @@ class VarGroup():
 
     def _parse_model(self, model, inputs):
         _logger.debug("Parsing model with input: {}".format(inputs))
-
-        model.eval()
+        # model can be in training mode, because some model contains auxiliary parameters for training.
         program = dygraph2program(model, inputs=inputs)
-
         graph = GraphWrapper(program)
-
         visited = {}
         for name, param in model.named_parameters():
             group = collect_convs([param.name], graph,

--- a/paddleslim/prune/group_param.py
+++ b/paddleslim/prune/group_param.py
@@ -58,7 +58,12 @@ def collect_convs(params, graph, visited={}):
     for param in params:
         pruned_params = []
         param = graph.var(param)
-
+        if param is None:
+            _logger.warn(
+                f"Cann't found relative variables of {param} because {param} is not in target program or model. Please make sure {param} is in your program if you are using static API of PaddlePaddle. And make sure your model in correctly mode and contains {param} if you are using dynamic API of PaddlePaddle."
+            )
+            groups.append([])
+            continue
         target_op = param.outputs()[0]
         if target_op.type() == 'conditional_block':
             for op in param.outputs():

--- a/paddleslim/prune/group_param.py
+++ b/paddleslim/prune/group_param.py
@@ -55,12 +55,12 @@ def collect_convs(params, graph, visited={}):
     if not isinstance(graph, GraphWrapper):
         graph = GraphWrapper(graph)
     groups = []
-    for param in params:
+    for _param in params:
         pruned_params = []
-        param = graph.var(param)
+        param = graph.var(_param)
         if param is None:
-            _logger.warn(
-                f"Cann't found relative variables of {param} because {param} is not in target program or model. Please make sure {param} is in your program if you are using static API of PaddlePaddle. And make sure your model in correctly mode and contains {param} if you are using dynamic API of PaddlePaddle."
+            _logger.warning(
+                f"Cann't found relative variables of {_param} because {_param} is not in target program or model. Please make sure {_param} is in your program if you are using static API of PaddlePaddle. And make sure your model in correctly mode and contains {_param} if you are using dynamic API of PaddlePaddle."
             )
             groups.append([])
             continue

--- a/paddleslim/prune/prune_walker.py
+++ b/paddleslim/prune/prune_walker.py
@@ -344,15 +344,10 @@ class activation(PruneWorker):
     def _prune(self, var, pruned_axis, pruned_idx):
         if var in self.op.outputs(self.output_name):
             in_var = self.op.inputs(self.input_name)[0]
-            pre_ops = in_var.inputs()
-            for op in pre_ops:
-                self._prune_op(op, in_var, pruned_axis, pruned_idx)
-
-        out_var = self.op.outputs(self.output_name)[0]
-        self._visit(out_var, pruned_axis)
-        next_ops = out_var.outputs()
-        for op in next_ops:
-            self._prune_op(op, out_var, pruned_axis, pruned_idx)
+            self._visit_and_search(in_var, pruned_axis, pruned_idx)
+        if var in self.op.inputs(self.input_name):
+            out_var = self.op.outputs(self.output_name)[0]
+            self._visit_and_search(out_var, pruned_axis, pruned_idx)
 
 
 @PRUNE_WORKER.register

--- a/paddleslim/prune/prune_walker.py
+++ b/paddleslim/prune/prune_walker.py
@@ -359,16 +359,10 @@ class default_walker(PruneWorker):
         if var in self.op.all_outputs():
             for in_var in self.op.all_inputs():
                 if len(in_var.shape()) == len(var.shape()):
-                    pre_ops = in_var.inputs()
-                    for op in pre_ops:
-                        self._prune_op(op, in_var, pruned_axis, pruned_idx)
-
+                    self._visit_and_search(in_var, pruned_axis, pruned_idx)
         for out_var in self.op.all_outputs():
             if len(out_var.shape()) == len(var.shape()):
-                self._visit(out_var, pruned_axis)
-                next_ops = out_var.outputs()
-                for op in next_ops:
-                    self._prune_op(op, out_var, pruned_axis, pruned_idx)
+                self._visit_and_search(out_var, pruned_axis, pruned_idx)
 
 
 @PRUNE_WORKER.register

--- a/paddleslim/prune/pruner.py
+++ b/paddleslim/prune/pruner.py
@@ -98,8 +98,8 @@ class Pruner():
                                   visited)[0]  # [(name, axis, pruned_idx)]
             if group is None or len(group) == 0:
                 continue
-            assert ((not self.pruned_weights),
-                    "The weights have been pruned once.")
+            assert (
+                not self.pruned_weights), "The weights have been pruned once."
             group_values = []
             for name, axis, pruned_idx in group:
                 var = scope.find_var(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 #paddlepaddle == 1.6.0rc0
 tqdm
 pyzmq
-matplotlib 
+matplotlib
+opencv-python
+pillow 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 #paddlepaddle == 1.6.0rc0
 tqdm
 pyzmq
+matplotlib 

--- a/tests/dygraph/test_prune_walker.py
+++ b/tests/dygraph/test_prune_walker.py
@@ -1,0 +1,33 @@
+import sys
+sys.path.append("../../")
+import unittest
+import numpy as np
+import paddle
+from paddleslim.dygraph import L1NormFilterPruner
+from paddle.nn import Conv2D, Linear, Layer
+
+
+class Net(Layer):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = Conv2D(3, 8, 3)
+        self.linear = Linear(8 * 30 * 30, 5)
+
+    def forward(self, x):
+        tmp = self.conv1(x)
+        tmp = paddle.flatten(tmp, 1)
+        return self.linear(tmp)
+
+
+class TestWalker(unittest.TestCase):
+    def runTest(self):
+        x_shape = (1, 3, 32, 32)
+        net = Net()
+        x = np.random.uniform(-1, 1, x_shape).astype('float32')
+        pruner = L1NormFilterPruner(net, [paddle.to_tensor(x)])
+        pruner.prune_vars({"conv2d_0.w_0": 0.2}, [0])
+        self.assertTrue(net.linear.weight.shape == [5400, 5])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_deep_mutual_learning.py
+++ b/tests/test_deep_mutual_learning.py
@@ -31,7 +31,7 @@ class Model(paddle.nn.Layer):
         super(Model, self).__init__()
         self.conv = paddle.nn.Conv2D(
             in_channels=1, out_channels=256, kernel_size=3, stride=1, padding=1)
-        self.pool2d_avg = paddle.nn.Pool2D(pool_type='avg', global_pooling=True)
+        self.pool2d_avg = paddle.nn.AdaptiveAvgPool2D([1, 1])
         self.out = paddle.nn.Linear(256, 10)
 
     def forward(self, inputs):

--- a/tests/test_dygraph_pruning_plan.py
+++ b/tests/test_dygraph_pruning_plan.py
@@ -8,13 +8,13 @@ from paddleslim.dygraph.pruning_plan import PruningPlan, PruningMask
 class TestPruningPlan(unittest.TestCase):
     def testAdd(self):
         plan = PruningPlan()
-        mask = PruningMask([0], [0, 0, 1], 0.33)
+        mask = PruningMask([0], [0, 1, 1], 0.33)
         plan.add("a", mask)
         mask = PruningMask([0], [0, 1, 0], 0.33)
         plan.add("a", mask)
         a_mask = plan.masks["a"]
         self.assertTrue(len(a_mask) == 1)
-        self.assertTrue(a_mask[0].mask == [0, 1, 1])
+        self.assertTrue(a_mask[0].mask == [0, 1, 0])
         self.assertTrue(a_mask[0].dims == [0])
 
 

--- a/tests/test_group_param.py
+++ b/tests/test_group_param.py
@@ -42,7 +42,8 @@ class TestPrune(StaticCase):
             conv5 = conv_bn_layer(sum2, 8, 3, "conv5")
             conv6 = conv_bn_layer(conv5, 8, 3, "conv6")
         collected_groups = collect_convs(
-            ["conv1_weights", "conv2_weights", "conv3_weights"], main_program)
+            ["conv1_weights", "conv2_weights", "conv3_weights", "dummy"],
+            main_program)
         while [] in collected_groups:
             collected_groups.remove([])
         print(collected_groups)


### PR DESCRIPTION
在某种场景下，评估网络和训练网络包含的参数并不一致，如下图所示。相比**Eval Graph**，**Training Graph**多了一个辅助模块，而在辅助模块中引入了一个包含可训练`Parameter`的卷积`conv2`。
<img width="543" alt="image" src="https://user-images.githubusercontent.com/7534971/105142405-86eceb00-5b35-11eb-9117-cb0d298fb5d1.png">

对于上图的场景，如果我们调用：
```
model.eval()
pruner = L1NormFilterPruner(model, inputs) # 这一步，pruner只能感知到`Eval Graph'中的`parameters`及其之间的关系。

# case1: 正确
pruner.prune_vars({"conv0": 0.5}, [0]) 
evaluate(model)

# case2: 错误
pruner.prune_vars({"conv0": 0.5}, [0])  # 虽然conv0和conv2是关联的，但是pruner感知不到`conv2`，所以没有对conv2剪裁，这就导致conv0和conv2的shape不兼容。
train(model) # 训练失败

# case3: 无效
pruner.prune_vars({"conv2": 0.5}, [0]) # pruner感知不到`conv2`, 会报warning。
train(model)  # 训练正常（相当于没剪枝）
```

如上图场景，如果有以下调用：
```
model.train()
pruner = L1NormFilterPruner(model, inputs) # pruner能感知到`Eval Graph'和`Training Graph`共享的parameter，以及`Training Graph`独有的parameters。

# case4: 正确
pruner.prune({"conv0": 0.5, "conv1": 0.5, "conv2": 0.5}, [0])
evaluate(model) # 正常
train(model) # 正常
```

