### PR TITLE
Remove the dygraph quantized layer type checking in slim

### DIFF
--- a/paddleslim/dygraph/quant/quanter.py
+++ b/paddleslim/dygraph/quant/quanter.py
@@ -33,8 +33,6 @@ BUILT_IN_PREPROCESS_TYPES = ['PACT']
 
 VALID_DTYPES = ['int8']
 
-DYGRAPH_QUANTIZABLE_TYPE = ['Conv2D', 'Linear']
-
 __all__ = ['QAT']
 
 _quant_config_default = {
@@ -119,11 +117,6 @@ def _parse_configs(user_config):
 
     assert isinstance(configs['quantizable_layer_type'], list), \
         "quantizable_layer_type must be a list"
-
-    for op_type in configs['quantizable_layer_type']:
-        assert (op_type in DYGRAPH_QUANTIZABLE_TYPE), "{} is not support, \
-                    now support op types are {}".format(
-            op_type, DYGRAPH_QUANTIZABLE_TYPE)
 
     return configs
 


### PR DESCRIPTION
因为Paddle 里的动态图量化有Layer的类型检查，并且也在持续增加可支持量化的Layer。

所以在Slim里也添加一个类型检查会比较难维护。
