### PR TITLE
fix key error

### DIFF
--- a/paddleslim/prune/sensitive.py
+++ b/paddleslim/prune/sensitive.py
@@ -209,4 +209,5 @@ def get_ratios_by_loss(sensitivities, loss):
                         _logger.info(losses, ratio, (r1 - r0) / (l1 - l0), i)
 
                 break
+            if i == 0: ratios[param] = 0.0
     return ratios


### PR DESCRIPTION
修复问题https://github.com/PaddlePaddle/PaddleSlim/issues/791 。

bug：调用get_ratios_by_loss(sensitivities, loss)方法时，如果给定的loss小于某些参数的最小精度损失，该参数则不会被加入到ratios字典中。
