### PR TITLE
Fix keyerror

### DIFF
--- a/paddleslim/prune/sensitive.py
+++ b/paddleslim/prune/sensitive.py
@@ -209,4 +209,5 @@ def get_ratios_by_loss(sensitivities, loss):
                         _logger.info(losses, ratio, (r1 - r0) / (l1 - l0), i)
 
                 break
+            if i == 0: ratios[param] = 0.0
     return ratios

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -18,7 +18,7 @@ import numpy
 import paddle
 import paddle.fluid as fluid
 from static_case import StaticCase
-from paddleslim.prune import sensitivity, merge_sensitive, load_sensitivities
+from paddleslim.prune import sensitivity, merge_sensitive, load_sensitivities, get_ratios_by_loss
 from layers import conv_bn_layer
 
 
@@ -107,8 +107,15 @@ class TestSensitivity(StaticCase):
             sensitivities_file="./sensitivities_file_2",
             pruned_ratios=[0.1, 0.2, 0.3, 0.4])
         self.assertTrue(params_sens == origin_sens)
-
         self.assertTrue(sens == origin_sens)
+
+        loss = 0.0
+        ratios = get_ratios_by_loss(sens, loss)
+        self.assertTrue(len(ratios) == len(sens))
+
+        loss = min(list(sens.get('conv4_weights').values())) - 0.01
+        ratios = get_ratios_by_loss(sens, loss)
+        self.assertTrue(len(ratios) == len(sens))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. 修复问题https://github.com/PaddlePaddle/PaddleSlim/issues/791 。
2. 添加 sensitivity.get_ratios_by_loss(sens, loss) 函数对应的unit test。

bug：调用get_ratios_by_loss(sens, loss)方法时，如果给定的loss小于某些参数的最小精度损失，该参数则不会被加入到ratios字典中。