### PR TITLE
fix cifar10 dataloader and model loading, test=develop

### DIFF
--- a/demo/dygraph/unstructured_pruning/README.md
+++ b/demo/dygraph/unstructured_pruning/README.md
@@ -89,7 +89,7 @@ python3.7 train.py --data imagenet --lr 0.05 --pruning_mode threshold --threshol
 
 ## 推理：
 ```bash
-python3.7 evalualte.py --pruned_model models/model-pruned.pdparams --data imagenet
+python3.7 evaluate.py --pruned_model models/model-pruned.pdparams --data imagenet
 ```
 
 **注意**，上述`pruned_model` 参数应该指向pdparams文件。

--- a/demo/dygraph/unstructured_pruning/README.md
+++ b/demo/dygraph/unstructured_pruning/README.md
@@ -89,8 +89,10 @@ python3.7 train.py --data imagenet --lr 0.05 --pruning_mode threshold --threshol
 
 ## 推理：
 ```bash
-python3.7 evalualte.py --pruned_model models/ --data imagenet
+python3.7 evalualte.py --pruned_model models/model-pruned.pdparams --data imagenet
 ```
+
+**注意：上述`pruned_model` 参数应该指向存储的*.pdparams文件。**
 
 剪裁训练代码示例：
 ```python

--- a/demo/dygraph/unstructured_pruning/README.md
+++ b/demo/dygraph/unstructured_pruning/README.md
@@ -92,7 +92,7 @@ python3.7 train.py --data imagenet --lr 0.05 --pruning_mode threshold --threshol
 python3.7 evalualte.py --pruned_model models/model-pruned.pdparams --data imagenet
 ```
 
-**注意：上述`pruned_model` 参数应该指向存储的*.pdparams文件。**
+**注意**，上述`pruned_model` 参数应该指向pdparams文件。
 
 剪裁训练代码示例：
 ```python

--- a/demo/dygraph/unstructured_pruning/evaluate.py
+++ b/demo/dygraph/unstructured_pruning/evaluate.py
@@ -67,8 +67,6 @@ def compress(args):
             start_time = time.time()
             x_data = data[0]
             y_data = paddle.to_tensor(data[1])
-            if args.data == 'cifar10':
-                y_data = paddle.unsqueeze(y_data, 1)
 
             logits = model(x_data)
             loss = F.cross_entropy(logits, y_data)

--- a/demo/dygraph/unstructured_pruning/train.py
+++ b/demo/dygraph/unstructured_pruning/train.py
@@ -145,8 +145,6 @@ def compress(args):
             start_time = time.time()
             x_data = data[0]
             y_data = paddle.to_tensor(data[1])
-            if args.data == 'cifar10':
-                y_data = paddle.unsqueeze(y_data, 1)
 
             logits = model(x_data)
             loss = F.cross_entropy(logits, y_data)
@@ -180,8 +178,6 @@ def compress(args):
             train_reader_cost += time.time() - reader_start
             x_data = data[0]
             y_data = paddle.to_tensor(data[1])
-            if args.data == 'cifar10':
-                y_data = paddle.unsqueeze(y_data, 1)
 
             train_start = time.time()
             logits = model(x_data)


### PR DESCRIPTION
Fix two issues:
1. In dynamic graph mode, remove the unsqueeze operation for cifar10's label object. This was a helper process for the wrong label shape generated by Paddle framework. But now the issue has been solved on Paddle side so we catch it up.
2. Clarify the format for the --pruned_model when calling demo/dygraph/unstructured_pruning/evaluate.py in the corresponding readme.