### PR TITLE
Set 'persistable' of buffers to false in pruning

### DIFF
--- a/paddleslim/dygraph/prune/pruning_plan.py
+++ b/paddleslim/dygraph/prune/pruning_plan.py
@@ -78,6 +78,8 @@ class PruningPlan():
         return self._masks
 
     def extend(self, plan):
+        if plan is None:
+            return
         assert (isinstance(plan, PruningPlan))
         for var_name in plan.masks:
             for mask in plan.masks[var_name]:
@@ -132,7 +134,8 @@ class PruningPlan():
             if backup_name not in sub_layer._buffers:
                 sub_layer.register_buffer(
                     backup_name,
-                    paddle.to_tensor(np.array(var_tmp.value().get_tensor())))
+                    paddle.to_tensor(np.array(var_tmp.value().get_tensor())),
+                    persistable=False)
                 _logger.debug("Backup values of {} into buffers.".format(
                     var_tmp.name))
 
@@ -180,8 +183,10 @@ class PruningPlan():
                         # The name of buffer can not contains "."
                         backup_name = param.name.replace(".", "_") + "_backup"
                         if backup_name not in sub_layer._buffers:
-                            sub_layer.register_buffer(backup_name,
-                                                      paddle.to_tensor(value))
+                            sub_layer.register_buffer(
+                                backup_name,
+                                paddle.to_tensor(value),
+                                persistable=False)
                             _logger.debug("Backup values of {} into buffers.".
                                           format(param.name))
                         expand_mask_shape = [1] * len(value.shape)
@@ -235,8 +240,10 @@ class PruningPlan():
                         # The name of buffer can not contains "."
                         backup_name = param.name.replace(".", "_") + "_backup"
                         if backup_name not in sub_layer._buffers:
-                            sub_layer.register_buffer(backup_name,
-                                                      paddle.to_tensor(value))
+                            sub_layer.register_buffer(
+                                backup_name,
+                                paddle.to_tensor(value),
+                                persistable=False)
                             _logger.debug("Backup values of {} into buffers.".
                                           format(param.name))
                         # save optimizer accumulators into layer buffer

--- a/paddleslim/dygraph/prune/unstructured_pruner.py
+++ b/paddleslim/dygraph/prune/unstructured_pruner.py
@@ -62,8 +62,10 @@ class UnstructuredPruner():
                 tmp_array = np.ones(param.shape, dtype=np.float32)
                 mask_name = "_".join([param.name.replace(".", "_"), "mask"])
                 if mask_name not in sub_layer._buffers:
-                    sub_layer.register_buffer(mask_name,
-                                              paddle.to_tensor(tmp_array))
+                    sub_layer.register_buffer(
+                        mask_name,
+                        paddle.to_tensor(tmp_array),
+                        persistable=False)
                 self.masks[param.name] = sub_layer._buffers[mask_name]
         for name, sub_layer in self.model.named_sublayers():
             sub_layer.register_forward_pre_hook(self._forward_pre_hook)


### PR DESCRIPTION
https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/Layer_cn.html#register_buffer
注册的buffer默认是可持久性的，会被保存到 state_dict 中。如果指定 persistable 参数为False，则会注册一个非持久性的buffer，即不会同步和保存到 state_dict 中。
所以，pruning中用于备份信息而临时注册的buffers会被保存到模型文件中。保存模型的调用如下：
```
paddle.save(model.state_dict)
```