### PR TITLE
fix imagenet reader, test=develop

### DIFF
--- a/demo/dygraph/unstructured_pruning/train.py
+++ b/demo/dygraph/unstructured_pruning/train.py
@@ -191,7 +191,7 @@ def compress(args):
             opt.clear_grad()
             pruner.step()
             train_run_cost += time.time() - train_start
-            total_samples += args.batch_size * ParallelEnv().nranks
+            total_samples += args.batch_size
 
             if batch_id % args.log_period == 0:
                 _logger.info(

--- a/demo/imagenet_reader.py
+++ b/demo/imagenet_reader.py
@@ -144,20 +144,7 @@ def _reader_creator(file_list,
                 full_lines = [line.strip() for line in flist]
                 if shuffle:
                     np.random.shuffle(full_lines)
-                if mode == 'train' and os.getenv('PADDLE_TRAINING_ROLE'):
-                    # distributed mode if the env var `PADDLE_TRAINING_ROLE` exits
-                    trainer_id = int(os.getenv("PADDLE_TRAINER_ID", "0"))
-                    trainer_count = int(os.getenv("PADDLE_TRAINERS_NUM", "1"))
-                    per_node_lines = len(full_lines) // trainer_count
-                    lines = full_lines[trainer_id * per_node_lines:(
-                        trainer_id + 1) * per_node_lines]
-                    print(
-                        "read images from %d, length: %d, lines length: %d, total: %d"
-                        % (trainer_id * per_node_lines, per_node_lines,
-                           len(lines), len(full_lines)))
-                else:
-                    lines = full_lines
-
+                lines = full_lines
                 for line in lines:
                     if mode == 'train' or mode == 'val':
                         img_path, label = line.split()


### PR DESCRIPTION
This PR removes the split of imagenet in distributed training. This is a duplicate operation as it has been implemented in Paddle framework, dataloader.DistributedBatchSampler: https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/dataloader/batch_sampler.py#L257