### PR TITLE
Skip unsupported op for pruning

### DIFF
--- a/paddleslim/core/graph_wrapper.py
+++ b/paddleslim/core/graph_wrapper.py
@@ -64,6 +64,8 @@ class VarWrapper(object):
         return self._var.name > other._var.name
 
     def __eq__(self, other):
+        if other is None:
+            return False
         return self._var.name == other._var.name
 
     def shape(self):

--- a/paddleslim/prune/idx_selector.py
+++ b/paddleslim/prune/idx_selector.py
@@ -26,7 +26,7 @@ IDX_SELECTOR = Registry('idx_selector')
 
 
 @IDX_SELECTOR.register
-def default_idx_selector(group, scores, ratios):
+def default_idx_selector(group, scores, ratios, cached_pruned_idx=None):
     """Get the pruned indices by scores of master tensor.
 
     This function return a list of parameters' pruned indices on given axis.
@@ -37,7 +37,8 @@ def default_idx_selector(group, scores, ratios):
     Args:
        group(Group): A group of pruning operations.
        scores(dict): The key is name of tensor, the value is a dict with axis as key and scores as value.
-       ratios(dict): The pruned ratio of each tensor. The key is name of tensor and the value is the pruned ratio. 
+       ratios(dict): The pruned ratio of each tensor. The key is name of tensor and the value is the pruned ratio.
+       cached_pruned_idx(dict): A dict cached pruned indexes computed in in previous steps.
      
     Returns:
 
@@ -47,39 +48,50 @@ def default_idx_selector(group, scores, ratios):
     # sort channels by the master convolution's score
     name = group.master["name"]
     axis = group.master["axis"]
-    score = scores[name][axis]
+    #    print(f"name: {name}; axis: {axis}")
+    if cached_pruned_idx is not None and name in cached_pruned_idx and axis in cached_pruned_idx[
+            name]:
+        pruned_idx = cached_pruned_idx[name][axis]
+    else:
+        score = scores[name][axis]
+        # get max convolution groups attribution
+        max_groups = 1
+        for pruning_details in group.all_pruning_details():
+            groups = pruning_details.op.attr("groups")
+            if groups is not None and groups > max_groups:
+                max_groups = groups
+        if max_groups > 1:
+            score = score.reshape([max_groups, -1])
+            group_size = score.shape[1]
+            # get score for each group of channels
+            score = np.mean(score, axis=1)
+        sorted_idx = score.argsort()
+        ratio = ratios[name]
+        pruned_num = int(round(len(sorted_idx) * ratio))
+        pruned_idx = sorted_idx[:pruned_num]
+        # convert indices of channel groups to indices of channels.
+        if max_groups > 1:
+            correct_idx = []
+            for idx in pruned_idx:
+                for offset in range(group_size):
+                    correct_idx.append(idx * group_size + offset)
+            pruned_idx = correct_idx[:]
 
-    # get max convolution groups attribution
-    max_groups = 1
-    for pruning_details in group.all_pruning_details():
-        groups = pruning_details.op.attr("groups")
-        if groups is not None and groups > max_groups:
-            max_groups = groups
-    if max_groups > 1:
-        score = score.reshape([max_groups, -1])
-        group_size = score.shape[1]
-        # get score for each group of channels
-        score = np.mean(score, axis=1)
-    sorted_idx = score.argsort()
-    ratio = ratios[name]
-    pruned_num = int(round(len(sorted_idx) * ratio))
-    pruned_idx = sorted_idx[:pruned_num]
-    # convert indices of channel groups to indices of channels.
-    if max_groups > 1:
-        correct_idx = []
-        for idx in pruned_idx:
-            for offset in range(group_size):
-                correct_idx.append(idx * group_size + offset)
-        pruned_idx = correct_idx[:]
+        if cached_pruned_idx is not None:
+            if name not in cached_pruned_idx:
+                cached_pruned_idx[name] = {}
+            cached_pruned_idx[name][axis] = pruned_idx
     ret = []
     for _pruning_details in group.all_pruning_details():
         ret.append((_pruning_details.name, _pruning_details.axis, pruned_idx,
                     _pruning_details.transform))
+
+#        print(f"name: {_pruning_details.name}; axis: {_pruning_details.axis}; pruned_idx: {pruned_idx}; trans: {_pruning_details.transform}")
     return ret
 
 
 @IDX_SELECTOR.register
-def optimal_threshold(group, scores, ratios):
+def optimal_threshold(group, scores, ratios, cached_pruned_idx=None):
     """Get the pruned indices by scores of master tensor.
 
     This function return a list of parameters' pruned indices on given axis.
@@ -91,6 +103,7 @@ def optimal_threshold(group, scores, ratios):
        group(Group): A group of pruning operations.
        scores(dict): The key is name of tensor, the value is a dict with axis as key and scores as value.
        ratios(dict): The pruned ratio of each tensor. The key is name of tensor and the value is the pruned ratio. 
+       cached_pruned_idx(dict): A dict cached pruned indexes computed in in previous steps.
      
     Returns:
        list: pruned indices with format (name, axis, pruned_indices).
@@ -101,18 +114,26 @@ def optimal_threshold(group, scores, ratios):
     score = scores[name][axis]
     ratio = ratios[name]
 
-    score[score < 1e-18] = 1e-18
-    score_sorted = np.sort(score)
-    score_square = score_sorted**2
-    total_sum = score_square.sum()
-    acc_sum = 0
-    for i in range(score_square.size):
-        acc_sum += score_square[i]
-        if acc_sum / total_sum > ratio:
-            break
-    th = (score_sorted[i - 1] + score_sorted[i]) / 2 if i > 0 else 0
+    if cached_pruned_idx is not None and name in cached_pruned_idx and axis in cached_pruned_idx[
+            name]:
+        pruned_idx = cached_pruned_idx[name][axis]
+    else:
+        score[score < 1e-18] = 1e-18
+        score_sorted = np.sort(score)
+        score_square = score_sorted**2
+        total_sum = score_square.sum()
+        acc_sum = 0
+        for i in range(score_square.size):
+            acc_sum += score_square[i]
+            if acc_sum / total_sum > ratio:
+                break
+        th = (score_sorted[i - 1] + score_sorted[i]) / 2 if i > 0 else 0
+        pruned_idx = np.squeeze(np.argwhere(score < th))
 
-    pruned_idx = np.squeeze(np.argwhere(score < th))
+        if cached_pruned_idx is not None:
+            if name not in cached_pruned_idx:
+                cached_pruned_idx[name] = {}
+            cached_pruned_idx[name][axis] = pruned_idx
 
     idxs = []
     for _pruning_details in group.all_pruning_details():

--- a/paddleslim/prune/pruner.py
+++ b/paddleslim/prune/pruner.py
@@ -49,6 +49,7 @@ class Pruner():
             self.idx_selector = idx_selector
 
         self.pruned_weights = False
+
         self.cached_pruned_idx = {}
 
     def _remove_unsupported_cases(self, params, ratios, graph):


### PR DESCRIPTION
## 背景

静态图下：

在剪枝过程中，需要剪裁的对象有：
- train program: 用于训练的网络结构，包括backward
- test program: 测试网络，只有forward
- scope: 所有变量的数值

在对train program和test program做剪枝时，需要根据scope中的变量数值确定各层的剪裁比例和剪裁indexes，
所以在剪裁program前，scope中的数值不能变化。pruner.prune方法中有`only_graph`选项，可以跳过剪裁scope。

以上背景**要求用户第一次调用pruner.pune时，要将only_graph设置为false.**

**该PR解除了以上约束。**

## 改进措施

在第一次pruner.prune调用时，将从scope计算得到的pruned indexes缓存到pruner实例中，后续的pruner.prune不再依赖scope。

