### PR TITLE
Support string input for ofa export

### DIFF
--- a/paddleslim/nas/ofa/ofa.py
+++ b/paddleslim/nas/ofa/ofa.py
@@ -36,6 +36,8 @@ from paddle.fluid import core
 from paddle.fluid.framework import Variable
 import numbers
 
+from paddlenlp.experimental import to_tensor
+
 _logger = get_logger(__name__, level=logging.INFO)
 
 __all__ = ['OFA', 'RunConfig', 'DistillConfig']
@@ -531,6 +533,8 @@ class OFA(OFABase):
                     dtype = dtypes[0]
                 else:
                     dtype = dtypes
+                if dtype == core.VarDesc.VarType.STRINGS:
+                    return to_tensor([""])
                 return paddle.cast(paddle.rand(list(input_size)), dtype)
             if isinstance(input_size, dict):
                 inputs = {}

--- a/paddleslim/nas/ofa/ofa.py
+++ b/paddleslim/nas/ofa/ofa.py
@@ -36,8 +36,6 @@ from paddle.fluid import core
 from paddle.fluid.framework import Variable
 import numbers
 
-from paddlenlp.experimental import to_tensor
-
 _logger = get_logger(__name__, level=logging.INFO)
 
 __all__ = ['OFA', 'RunConfig', 'DistillConfig']
@@ -79,6 +77,21 @@ DistillConfig = namedtuple(
         'mapping_op'
     ])
 DistillConfig.__new__.__defaults__ = (None, ) * len(DistillConfig._fields)
+
+
+def to_tensor(string_values, name="text"):
+    """
+    Create the tensor that the value holds the list of string.
+    NOTICE: The value will be holded in the cpu place.
+
+    Parameters:
+        string_values(list[string]): The value will be setted to the tensor.
+        name(string): The name of the tensor.
+    """
+    tensor = paddle.Tensor(core.VarDesc.VarType.STRING, [], name,
+                           core.VarDesc.VarType.STRINGS, False)
+    tensor.value().set_string_list(string_values)
+    return tensor
 
 
 class OFABase(Layer):

--- a/paddleslim/quant/quanter.py
+++ b/paddleslim/quant/quanter.py
@@ -307,6 +307,7 @@ def quant_post_static(
         quantize_model_path,
         batch_generator=None,
         sample_generator=None,
+        data_loader=None,
         model_filename=None,
         params_filename=None,
         save_model_filename='__model__',
@@ -346,6 +347,9 @@ def quant_post_static(
                 can be set. Beisdes, batch_generator supports lod tensor.
         sample_generator(Python Generator): The sample generator provides 
             calibrate data for DataLoader, and it only returns a sample every time.
+        data_loader(Python Generator, Paddle.io.DataLoader, optional): The
+            Generator or Dataloader provides calibrate data, and it could
+            return a batch every time.
         model_filename(str, optional): The name of model file. If parameters 
             are saved in separate files, set it as 'None'. Default: 'None'.
         params_filename(str, optional): The name of params file.
@@ -399,6 +403,7 @@ def quant_post_static(
         executor=executor,
         sample_generator=sample_generator,
         batch_generator=batch_generator,
+        data_loader=data_loader,
         model_dir=model_dir,
         model_filename=model_filename,
         params_filename=params_filename,


### PR DESCRIPTION
小模型 PPMiniLM 接入 FasterTokenizer，输入由`input_ids (Tensor)`, `segment_ids(Tensor)` 变成 `text(list[string])`

小模型同时接入 ofa 裁剪功能，需要借助ofa的 `export` 导出裁剪后的模型

因此，ofa的 `export` 中 `build_input` 需要支持产生 dtype 为 `paddle.fluid.core.VarDesc.VarType.STRINGS` 的输入