### PR TITLE
fix InvalidArgumentError while training slimface

### DIFF
--- a/demo/models/slimfacenet.py
+++ b/demo/models/slimfacenet.py
@@ -334,7 +334,7 @@ class SlimFaceNet():
         else:
             pass
 
-        one_hot = fluid.one_hot(input=label, depth=out_dim)
+        one_hot = fluid.layers.one_hot(input=label, depth=out_dim)
         output = fluid.layers.elementwise_mul(
             one_hot, phi) + fluid.layers.elementwise_mul(
                 (1.0 - one_hot), cosine)
@@ -367,7 +367,8 @@ def SlimFaceNet_C_x0_75(class_dim=None, scale=0.6, arch=None):
 
 
 if __name__ == "__main__":
+    paddle.enable_static()
     x = fluid.data(name='x', shape=[-1, 3, 112, 112], dtype='float32')
     print(x.shape)
-    model = SlimFaceNet(10000, [1, 3, 3, 1, 1, 0, 0, 1, 0, 1, 1, 0, 5, 5, 3])
+    model = SlimFaceNet(10000, arch=[1, 3, 3, 1, 1, 0, 0, 1, 0, 1, 1, 0, 5, 5, 3])
     y = model.net(x)

--- a/demo/slimfacenet/train_eval.py
+++ b/demo/slimfacenet/train_eval.py
@@ -29,6 +29,7 @@ from lfw_eval import parse_filelist, evaluation_10_fold
 from paddleslim import models
 from paddleslim.quant import quant_post_static
 
+paddle.enable_static()
 
 def now():
     return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))


### PR DESCRIPTION
Ubuntu 20.04
```
(base) luke@luke-NH5x-7xRCx-RDx:~$ pip list|grep paddle
paddle-upgrade-tool           0.0.27
paddle2onnx                   0.9.5
paddlefsl                     1.1.0
paddlehub                     2.2.0
paddlenlp                     2.2.6
paddlepaddle-gpu              2.2.2
paddleslim                    2.2.2
paddleslim-opt-tools          2.11
```

```
(base) luke@luke-NH5x-7xRCx-RDx:~/PaddleSlim/demo/slimfacenet$ sh slim_train.sh 
/home/luke/miniconda3/lib/python3.9/site-packages/fontTools/misc/py23.py:11: DeprecationWarning: The py23 module has been deprecated and will be removed in a future release. Please update your code.
  warnings.warn(
Namespace(action='train', model='SlimFaceNet_B_x0_75', use_gpu=1, lr_strategy='piecewise_decay', lr=0.1, lr_list='0.1,0.01,0.001,0.0001', lr_steps='36,52,58', l2_decay=4e-05, train_data_dir='/home/luke/CASIA/', test_data_dir='/home/luke/lfw/', train_batchsize=128, test_batchsize=128, img_shape='3,112,96', start_epoch=0, total_epoch=80, save_frequency=1, save_ckpt='output', feature_save_dir='result.mat')
num_trainers: 1
/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layers/math_op_patch.py:336: UserWarning: /home/luke/miniconda3/lib/python3.9/site-packages/paddleslim/models/slimfacenet.py:325
The behavior of expression A - B has been unified with elementwise_sub(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_sub(X, Y, axis=0) instead of A - B. This transitional warning will be dropped in the future.
  warnings.warn(
/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/framework.py:744: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  elif dtype == np.bool:
/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layers/math_op_patch.py:336: UserWarning: /home/luke/miniconda3/lib/python3.9/site-packages/paddleslim/models/slimfacenet.py:346
The behavior of expression A + B has been unified with elementwise_add(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_add(X, Y, axis=0) instead of A + B. This transitional warning will be dropped in the future.
  warnings.warn(
/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layers/math_op_patch.py:336: UserWarning: /home/luke/miniconda3/lib/python3.9/site-packages/paddleslim/models/slimfacenet.py:338
The behavior of expression A + B has been unified with elementwise_add(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_add(X, Y, axis=0) instead of A + B. This transitional warning will be dropped in the future.
  warnings.warn(
W0505 11:56:48.561714  2622 device_context.cc:447] Please NOTE: device: 0, GPU Compute Capability: 7.5, Driver API Version: 11.6, Runtime API Version: 10.2
W0505 11:56:48.563758  2622 device_context.cc:465] device: 0, cuDNN Version: 7.6.
/home/luke/miniconda3/lib/python3.9/site-packages/imageio/__init__.py:89: DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning dissapear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.
  warnings.warn(
W0505 11:56:50.461360  2622 fuse_optimizer_op_pass.cc:203] Find momentum operators : 234, and 234 for dense gradients. To make the speed faster, those optimization are fused during training.
Traceback (most recent call last):
  File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 386, in <module>
    main()
  File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 333, in main
    train(exe, train_program, train_out, test_program, test_out, args)
  File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 127, in train
    loss, acc, global_lr = exe.run(compiled_prog,
  File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/executor.py", line 1262, in run
    six.reraise(*sys.exc_info())
  File "/home/luke/miniconda3/lib/python3.9/site-packages/six.py", line 719, in reraise
    raise value
  File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/executor.py", line 1250, in run
    return self._run_impl(
  File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/executor.py", line 1408, in _run_impl
    return self._run_parallel(
  File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/executor.py", line 1065, in _run_parallel
    tensors = exe.run(fetch_var_names, return_merged)._move_to_list()
ValueError: In user code:

    File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 386, in <module>
      main()
    File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 325, in main
      train_out = build_program(train_program, startup_program, args, True)
    File "/home/luke/PaddleSlim/demo/slimfacenet/train_eval.py", line 185, in build_program
      loss, acc = model.net(image, label)
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddleslim/models/slimfacenet.py", line 176, in net
      cost = fluid.layers.cross_entropy(input=softmax, label=label)
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layers/loss.py", line 263, in cross_entropy
      return cross_entropy2(input, label, ignore_index)
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layers/loss.py", line 295, in cross_entropy2
      helper.append_op(
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/layer_helper.py", line 43, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/framework.py", line 3178, in append_op
      op = Operator(
    File "/home/luke/miniconda3/lib/python3.9/site-packages/paddle/fluid/framework.py", line 2224, in __init__
      for frame in traceback.extract_stack():

    InvalidArgumentError: Input(X) and Input(Label) shall have the same shape except the last dimension. But received: the shape of Input(X) is [128, 128, 10572], the shape of Input(Label) is [128, 1].
      [Hint: Expected framework::slice_ddim(x_dims, 0, rank - 1) == framework::slice_ddim(label_dims, 0, rank - 1), but received framework::slice_ddim(x_dims, 0, rank - 1):128, 128 != framework::slice_ddim(label_dims, 0, rank - 1):128, 1.] (at /paddle/paddle/fluid/operators/cross_entropy_op.cc:49)
      [operator < cross_entropy2 > error]
```