### PR TITLE
[Eager]Support dygraph2program for Eager Mode without program_desc_tracing

### DIFF
--- a/tests/test_dy2prog.py
+++ b/tests/test_dy2prog.py
@@ -1,0 +1,66 @@
+import os
+import sys
+sys.path.append("../")
+import paddle
+import unittest
+from paddleslim.core import dygraph2program
+
+
+class Model(paddle.nn.Layer):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.conv = paddle.nn.Conv2D(
+            in_channels=1, out_channels=256, kernel_size=3, stride=1, padding=1)
+        self.pool2d_avg = paddle.nn.AdaptiveAvgPool2D([1, 1])
+        self.out = paddle.nn.Linear(256, 10)
+
+    def forward(self, inputs):
+        inputs = paddle.reshape(inputs, shape=[0, 1, 28, 28])
+        y = self.conv(inputs)
+        y = self.pool2d_avg(y)
+        y = paddle.reshape(y, shape=[-1, 256])
+        y = self.out(y)
+        return y
+
+
+class TestEagerDygraph2Program(unittest.TestCase):
+    def setUp(self):
+        os.environ['FLAGS_enable_eager_mode'] = "1"
+        self.prepare_inputs()
+        self.prepare_layer()
+
+    def prepare_inputs(self):
+        self.inputs = [3, 28, 28]
+
+    def prepare_layer(self):
+        self.layer = Model()
+
+    def test_dy2prog(self):
+        program = dygraph2program(self.layer, self.inputs)
+        self.assert_program(program)
+
+    def assert_program(self, program):
+        ops = [
+            'reshape2', 'conv2d', 'elementwise_add', 'pool2d', 'reshape2',
+            'matmul_v2', 'elementwise_add'
+        ]
+        self.assertListEqual([op.type for op in program.block(0).ops], ops)
+
+
+class TestEagerDygraph2Program2(TestEagerDygraph2Program):
+    def prepare_inputs(self):
+        self.inputs = [[3, 28, 28]]
+
+
+class TestEagerDygraph2Program3(TestEagerDygraph2Program):
+    def prepare_inputs(self):
+        self.inputs = paddle.randn([3, 28, 28])
+
+
+class TestEagerDygraph2Program4(TestEagerDygraph2Program):
+    def prepare_inputs(self):
+        self.inputs = [paddle.randn([3, 28, 28])]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What's New?

新动态图下暂无支持 program_desc_tracing 的计划，因此需要适配新的 dygraph2program 函数实现。

+ 通过`FLAGS_enable_eager_mode` 环境变量来自适应切换到`_dy2prog`函数，FLAGS与主框架保持一致
+ 不再使用desc_tracing，而是在静态图下执行模型代码，与之前保持功能一致，且不支持控制流
+ 待后续主框架默认切换到Eager模式后，直接将`_dy2prog` 修改为 `dygraph2program` 即可