### PR TITLE
[Eager]Support final_state_layer_norm for SuperLayerNorm

### DIFF
--- a/paddleslim/nas/ofa/layers.py
+++ b/paddleslim/nas/ofa/layers.py
@@ -20,6 +20,8 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.fluid.core as core
+from paddle import _C_ops
+from paddle import in_dynamic_mode
 
 from ...common import get_logger
 from .utils.utils import compute_start_end, get_same_padding, convert_to_list
@@ -1180,9 +1182,13 @@ class SuperLayerNorm(nn.LayerNorm):
             bias = None
         self.cur_config = {'prune_dim': feature_dim}
 
-        out, _, _ = core.ops.layer_norm(input, weight, bias, 'epsilon',
-                                        self._epsilon, 'begin_norm_axis',
-                                        begin_norm_axis)
+        if in_dynamic_mode():
+            out, _, _, = _C_ops.final_state_layer_norm(
+                input, weight, bias, self._epsilon, begin_norm_axis, False)
+        else:
+            out, _, _ = core.ops.layer_norm(input, weight, bias, 'epsilon',
+                                            self._epsilon, 'begin_norm_axis',
+                                            begin_norm_axis)
         return out
 
 

--- a/paddleslim/nas/ofa/layers.py
+++ b/paddleslim/nas/ofa/layers.py
@@ -21,7 +21,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.fluid.core as core
 from paddle import _C_ops
-from paddle import in_dynamic_mode
+from paddle.fluid.framework import in_dygraph_mode
 
 from ...common import get_logger
 from .utils.utils import compute_start_end, get_same_padding, convert_to_list
@@ -1182,7 +1182,7 @@ class SuperLayerNorm(nn.LayerNorm):
             bias = None
         self.cur_config = {'prune_dim': feature_dim}
 
-        if in_dynamic_mode():
+        if in_dygraph_mode():
             out, _, _, = _C_ops.final_state_layer_norm(
                 input, weight, bias, self._epsilon, begin_norm_axis, False)
         else:


### PR DESCRIPTION
SuperLayerNorm 的forward函数使用的是旧的 core.ops.xxx，此PR 新增final_state_layer_norm以支持Eager模式。在Paddle NLP的ofa任务上验证了正确性。（之前切eager模式时，这些模型会报错）

复现命令：
```
##克隆代码编译安装（要先安装好paddle）
依赖paddleslim
python -m pip install paddleslim
git clone https://github.com/PaddlePaddle/PaddleNLP.git
python -m pip install jieba multiprocess colorlog colorama seqeval sentencepiece
cd PaddleNLP
python setup.py bdist_wheel
cd dist
python -m pip install paddlenlp-2.3.0.dev0-py3-none-any.whl
cd ..
##执行第一步预训练：
export CUDA_VISIBLE_DEVICES=0
export FLAGS_enable_eager_mode=1  # 开启新动态图
cd examples/benchmark/glue/
python -u ./run_glue.py \
    --model_type bert \
    --model_name_or_path bert-base-uncased \
    --task_name SST-2 \
    --max_seq_length 128 \
    --batch_size 10   \
    --learning_rate 2e-5 \
    --num_train_epochs 1 \
    --logging_steps 1 \
    --max_steps 10 \
    --save_steps 10 \
    --output_dir ./tmp/SST-2/single/ \
    --device gpu
## 执行第二部训练train(报错)
cd examples/model_compression/ofa/
python -m paddle.distributed.launch --gpus 0 run_glue_ofa.py \
    --model_type bert \
    --model_name_or_path ../../benchmark/glue/tmp/SST-2/single/sst-2_ft_model_10.pdparams \
    --task_name SST-2 \
    --max_seq_length 128 \
    --batch_size 32 \
    --learning_rate 2e-5 \
    --num_train_epochs 1 \
    --logging_steps 1 \
    --save_steps 1 \
    --max_steps 5 \
    --device gpu \
    --output_dir ./tmp/SST-2/single/ \
    --width_mult_list 1.0 0.8333333333333334 0.6666666666666666 0.5
```