### PR TITLE
Skip auto tuning when shape of model's input is variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     sha: 0d79c0c469bab64f7229c9aca2b1186ef47f0e37
     hooks:
     -   id: yapf
+        language_version: python3.9
         files: (.*\.(py|bzl)|BUILD|.*\.BUILD|WORKSPACE)$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: 5bf6c09bfa1297d3692cadd621ef95f1284e33c0

--- a/paddleslim/analysis/extract_features.py
+++ b/paddleslim/analysis/extract_features.py
@@ -50,7 +50,6 @@ def get_features_from_paramkey(param_key, op_type, data_type):
     """Get op's parameters according to the key of latency table
     """
     features = None
-
     if 'conv2d' in op_type:
         if data_type == 'fp16':
             quant_bits = 'bit_length=16'

--- a/paddleslim/auto_compression/auto_strategy.py
+++ b/paddleslim/auto_compression/auto_strategy.py
@@ -16,7 +16,7 @@ import os
 import logging
 import platform
 from ..common import get_logger
-from .utils.predict import predict_compressed_model
+from .utils.predict import predict_compressed_model, with_variable_shape
 from .strategy_config import *
 
 _logger = get_logger(__name__, level=logging.INFO)
@@ -140,7 +140,9 @@ def create_train_config(strategy_str, model_type):
     return train_config
 
 
-def prepare_strategy(model_dir,
+def prepare_strategy(executor,
+                     places,
+                     model_dir,
                      model_filename,
                      params_filename,
                      target_speedup=None,
@@ -149,9 +151,21 @@ def prepare_strategy(model_dir,
     """ prepare compression config automatically """
     final_strategy = None
 
+    if with_variable_shape(
+            model_dir,
+            model_filename=model_filename,
+            params_filename=params_filename):
+        deploy_hardware = None
+        _logger.warning(
+            "The model's inputs have variable shape. "
+            "And the latency predictor doesn't support variable shape. "
+            "So auto tuning will be skipped and a default strategy will be chosen."
+        )
     ### use hardware latency tabel if support
     if deploy_hardware is not None:
         compressed_time_dict = predict_compressed_model(
+            executor,
+            places,
             model_dir,
             model_filename,
             params_filename,

--- a/paddleslim/auto_compression/utils/predict.py
+++ b/paddleslim/auto_compression/utils/predict.py
@@ -1,12 +1,38 @@
 import os
+import shutil
 import paddle
-from paddleslim.analysis import TableLatencyPredictor
+from ...analysis import TableLatencyPredictor
 from .prune_model import get_sparse_model, get_prune_model
 from .fake_ptq import post_quant_fake
-import shutil
 
 
-def predict_compressed_model(model_dir,
+def with_variable_shape(model_dir, model_filename=None, params_filename=None):
+    """
+    Whether the shape of model's input is variable.
+    Args:
+        path_prefix(str | None): Directory path to save model + model name without suffix.
+        model_filename(str): specify model_filename if you don't want to use default name. Default : 'None'.
+        params_filename(str): specify params_filename if you don't want to use default name. Default : 'None'.
+    Returns:
+        bool: Whether the shape of model's input is variable.
+    """
+    paddle.enable_static()
+    exe = paddle.static.Executor(paddle.CPUPlace())
+    [inference_program, feed_target_names, fetch_targets] = (
+        paddle.static.load_inference_model(
+            model_dir,
+            exe,
+            model_filename=model_filename,
+            params_filename=params_filename))
+    for var_ in inference_program.list_vars():
+        if var_.name in feed_target_names:
+            if var_.shape.count(-1) > 1:
+                return True
+
+
+def predict_compressed_model(executor,
+                             places,
+                             model_dir,
                              model_filename,
                              params_filename,
                              hardware='SD710'):
@@ -41,10 +67,8 @@ def predict_compressed_model(model_dir,
         model_file=model_file, param_file=param_file, data_type='fp32')
     latency_dict.update({'origin_fp32': latency})
     paddle.enable_static()
-    place = paddle.CPUPlace()
-    exe = paddle.static.Executor(place)
     post_quant_fake(
-        exe,
+        executor,
         model_dir=model_dir,
         model_filename=model_filename,
         params_filename=params_filename,
@@ -64,6 +88,8 @@ def predict_compressed_model(model_dir,
 
     for prune_ratio in [0.3, 0.4, 0.5, 0.6]:
         get_prune_model(
+            executor,
+            places,
             model_file=model_file,
             param_file=param_file,
             ratio=prune_ratio,
@@ -78,7 +104,7 @@ def predict_compressed_model(model_dir,
         latency_dict.update({f'prune_{prune_ratio}_fp32': latency})
 
         post_quant_fake(
-            exe,
+            executor,
             model_dir=prune_model_path,
             model_filename=model_filename,
             params_filename=params_filename,
@@ -98,6 +124,8 @@ def predict_compressed_model(model_dir,
 
     for sparse_ratio in [0.70, 0.75, 0.80, 0.85, 0.90, 0.95]:
         get_sparse_model(
+            executor,
+            places,
             model_file=model_file,
             param_file=param_file,
             ratio=sparse_ratio,
@@ -112,7 +140,7 @@ def predict_compressed_model(model_dir,
         latency_dict.update({f'sparse_{sparse_ratio}_fp32': latency})
 
         post_quant_fake(
-            exe,
+            executor,
             model_dir=sparse_model_path,
             model_filename=model_filename,
             params_filename=params_filename,


### PR DESCRIPTION
在延时预估器中，会根据正则表达式 r'in=(\(-*\d*, \d*, \d*, \d*\))'从`param_key`中匹配OP输入的shape。
当param_key为以下字符串时，匹配失败，原因是input shape中不能有多个-1，即输入不能是变长。
```
pool2d in=(-1, 128, -1, -1) out=(-1, 128, -1, -1) stride=2 kernel=3x3 pad=1 flag_global=0 type=avg
```

处理方法：
判断推理模型的输入是否是变长输入，如果是则将hardware设置为None, 不使用延时预估选择压缩策略。