### PR TITLE
support train_iter in act

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
     sha: 0d79c0c469bab64f7229c9aca2b1186ef47f0e37
     hooks:
     -   id: yapf
-        language_version: python3.9
         files: (.*\.(py|bzl)|BUILD|.*\.BUILD|WORKSPACE)$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: 5bf6c09bfa1297d3692cadd621ef95f1284e33c0

--- a/demo/auto_compression/detection/configs/ppyoloe_l_qat_dis.yaml
+++ b/demo/auto_compression/detection/configs/ppyoloe_l_qat_dis.yaml
@@ -34,7 +34,7 @@ Quantization:
   - depthwise_conv2d
 
 TrainConfig:
-  epochs: 1
+  train_iter: 3000
   eval_iter: 1000
   learning_rate: 0.00001
   optimizer: SGD

--- a/demo/auto_compression/detection/configs/tinypose_reader.yml
+++ b/demo/auto_compression/detection/configs/tinypose_reader.yml
@@ -30,7 +30,7 @@ EvalDataset:
     use_gt_bbox: True
     image_thre: 0.5
 
-worker_num: 2
+worker_num: 0
 global_mean: &global_mean [0.485, 0.456, 0.406]
 global_std: &global_std [0.229, 0.224, 0.225]
 

--- a/demo/auto_compression/detection/configs/yolo_reader.yml
+++ b/demo/auto_compression/detection/configs/yolo_reader.yml
@@ -14,7 +14,7 @@ EvalDataset:
     anno_path: annotations/instances_val2017.json
     dataset_dir: dataset/coco/
 
-worker_num: 4
+worker_num: 0
 
 # preprocess reader in test
 EvalReader:

--- a/demo/auto_compression/detection/configs/yolov3_mbv1_qat_dis.yaml
+++ b/demo/auto_compression/detection/configs/yolov3_mbv1_qat_dis.yaml
@@ -34,7 +34,7 @@ Quantization:
   - depthwise_conv2d
 
 TrainConfig:
-  epochs: 1
+  train_iter: 3000
   eval_iter: 1000
   learning_rate: 0.0001
   optimizer: SGD

--- a/demo/auto_compression/detection/configs/yolov5_reader.yml
+++ b/demo/auto_compression/detection/configs/yolov5_reader.yml
@@ -14,7 +14,7 @@ EvalDataset:
     anno_path: annotations/instances_val2017.json
     dataset_dir: dataset/coco/
 
-worker_num: 4
+worker_num: 0
 
 # preprocess reader in test
 EvalReader:

--- a/demo/auto_compression/detection/configs/yolov5s_qat_dis.yaml
+++ b/demo/auto_compression/detection/configs/yolov5s_qat_dis.yaml
@@ -19,7 +19,7 @@ Distillation:
   - teacher_conv2d_119.tmp_1
   - conv2d_119.tmp_1
   merge_feed: true
-  teacher_model_dir: ./yolov5_inference_model/
+  teacher_model_dir: ./yolov5s_infer/
   teacher_model_filename: model.pdmodel
   teacher_params_filename: model.pdiparams
 
@@ -37,7 +37,7 @@ Quantization:
   - depthwise_conv2d
 
 TrainConfig:
-  epochs: 1
+  train_iter: 3000
   eval_iter: 1000
   learning_rate: 0.00001
   optimizer: SGD

--- a/paddleslim/auto_compression/strategy_config.py
+++ b/paddleslim/auto_compression/strategy_config.py
@@ -103,11 +103,24 @@ UnstructurePrune = namedtuple("UnstructurePrune", [
 UnstructurePrune.__new__.__defaults__ = (None, ) * len(UnstructurePrune._fields)
 
 ### Train
-TrainConfig = namedtuple("Train", [
-    "epochs", "learning_rate", "optimizer", "optim_args", "eval_iter",
-    "logging_iter", "origin_metric", "target_metric", "use_fleet", "amp_config",
-    "recompute_config", "sharding_config", "sparse_model"
-])
+TrainConfig = namedtuple(
+    "Train",
+    [
+        "epochs",  # Training total epoch
+        "train_iter",  # Training total iteration, `epochs` or `train_iter` only need to set one.
+        "learning_rate",
+        "optimizer",
+        "optim_args",
+        "eval_iter",
+        "logging_iter",
+        "origin_metric",
+        "target_metric",
+        "use_fleet",
+        "amp_config",
+        "recompute_config",
+        "sharding_config",
+        "sparse_model",
+    ])
 
 TrainConfig.__new__.__defaults__ = (None, ) * len(TrainConfig._fields)
 


### PR DESCRIPTION
由于一些数据集1个epoch周期很漫长，所以新增train_iter属性，可自定义迭代轮数，无需训完整epoch。