### PR TITLE
[bug fix] "%H:%M:%S" ->  "%H_%M_%S"

### DIFF
--- a/paddleslim/auto_compression/compressor.py
+++ b/paddleslim/auto_compression/compressor.py
@@ -554,7 +554,7 @@ class AutoCompression:
 
     def create_tmp_dir(self, base_dir, prefix="tmp"):
         # create a new temp directory in final dir
-        s_datetime = strftime("%Y-%m-%d-%H:%M:%S", gmtime())
+        s_datetime = strftime("%Y-%m-%d-%H_%M_%S", gmtime())
         tmp_base_name = "_".join([prefix, str(os.getpid()), s_datetime])
         tmp_dir = os.path.join(base_dir, tmp_base_name)
         if not os.path.exists(tmp_dir):


### PR DESCRIPTION
Hi, thank you for your auto_compression code. It's very very cooooool!!!

---

In windows platform, the file name can't include any char of the string `\/:*?"<>|`.

So, if one don't change, it raise:
```
*** OSError: [WinError 123] 文件名、目录名或卷标语法不正确。: './save_sparse_model\\tmp_8584_2022-07-22-04:12:48'
```

We can change ":" with "_" for platform compatibility.