### PR TITLE
Use fixed-shape models for hardware-aware automatic strategy selection.

### DIFF
--- a/example/auto_compression/semantic_segmentation/configs/pp_humanseg/pp_humanseg_auto.yaml
+++ b/example/auto_compression/semantic_segmentation/configs/pp_humanseg/pp_humanseg_auto.yaml
@@ -4,6 +4,7 @@ Global:
   model_filename: model.pdmodel
   params_filename: model.pdiparams
   deploy_hardware: SD710
+  input_shapes: [1,3,398,224,224]
 
 TrainConfig:
   epochs: 14

--- a/example/auto_compression/semantic_segmentation/configs/pp_humanseg/pp_humanseg_auto.yaml
+++ b/example/auto_compression/semantic_segmentation/configs/pp_humanseg/pp_humanseg_auto.yaml
@@ -4,7 +4,7 @@ Global:
   model_filename: model.pdmodel
   params_filename: model.pdiparams
   deploy_hardware: SD710
-  input_shapes: [1,3,398,224,224]
+  input_shapes: [1,3,398,224]
 
 TrainConfig:
   epochs: 14

--- a/example/auto_compression/semantic_segmentation/run.py
+++ b/example/auto_compression/semantic_segmentation/run.py
@@ -164,7 +164,8 @@ def main(args):
         config=all_config,
         train_dataloader=train_dataloader,
         eval_callback=eval_function if nranks > 1 and rank_id != 0 else None,
-        deploy_hardware=config.get('deploy_hardware') or None)
+        deploy_hardware=config.get('deploy_hardware') or None,
+        input_shapes=config.get('input_shapes', None))
 
     # step3: start the compression job
     ac.compress()


### PR DESCRIPTION
The latency predictor only supports fixed-shape models, so input shapes' information is required when using hardware-aware automatic strategy selection.