### PR TITLE
replace_static.sparsity_with_incubate.asp

### DIFF
--- a/paddleslim/auto_compression/create_compressed_program.py
+++ b/paddleslim/auto_compression/create_compressed_program.py
@@ -539,8 +539,8 @@ def build_prune_program(executor,
         train_program_info.program = pruned_program
 
     elif strategy.startswith('asp'):
-        from paddle.static import sparsity
-        pruner = sparsity
+        from paddle.incubate import asp
+        pruner = asp
         excluded_params_name = []
         if config['prune_params_name'] is None:
             config['prune_params_name'] = _get_asp_prune_params(


### PR DESCRIPTION
### What happened？
paddle.static.sparsity has been removed and is now replaced by paddle.incubate.asp.
see pr for details.
https://github.com/PaddlePaddle/Paddle/pull/48450

### What did I do？
replace paddle.static.sparsity with paddle.incubate.asp
**This change will not be compatible with versions prior to paddle 2.4**

### What did you expect to happen？
eliminate the impact of removing paddle.static.sparsity

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS