### PR TITLE
set opencv-python==4.6.0.66

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pillow
 pyyaml
 scikit-learn
 swig
+opencv-python==4.6.0.66


### PR DESCRIPTION
因opencv-python最新版本存在问题：https://github.com/opencv/opencv-python/issues/765
影响到CI、CE的使用；故先指定opencv-python==4.6.0.66，规避问题；

