### PR TITLE
修复与新版本paddle使用时返回值无法对应的问题。fix:paddle._C_ops.layer_norm()

### DIFF
--- a/paddleslim/nas/ofa/layers.py
+++ b/paddleslim/nas/ofa/layers.py
@@ -1298,7 +1298,7 @@ class SuperLayerNorm(paddle.nn.LayerNorm):
         self.cur_config = {'prune_dim': feature_dim}
 
         if paddle.in_dynamic_mode():
-            out, _, _ = paddle._C_ops.layer_norm(
+            out = paddle._C_ops.layer_norm(
                 input, weight, bias, self._epsilon, begin_norm_axis, False)
         else:
             paddle.common_ops_import.check_variable_and_dtype(


### PR DESCRIPTION
我的版本：

paddle2onnx               1.2.9
paddlefsl                 1.1.0
paddlenlp                 2.8.1
paddlepaddle-gpu          2.6.2
paddleslim                2.6.0

问题：
执行模型压缩的时候，会遇到报错：

Traceback (most recent call last):
  File "/root/workspace/uie_compress/compress_token_cls.py", line 102, in <module>
    main()
  File "/root/workspace/uie_compress/compress_token_cls.py", line 98, in main
    trainer.compress()
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/trainer/trainer_compress.py", line 73, in compress
    _dynabert(self, self.model)
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/trainer/trainer_compress.py", line 158, in _dynabert
    ofa_model, teacher_model = _dynabert_init(self, model, eval_dataloader)
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/trainer/trainer_compress.py", line 300, in _dynabert_init
    head_importance, neuron_importance = compute_neuron_head_importance(
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/transformers/ofa_utils.py", line 307, in compute_neuron_head_importance
    logits = model(**batch)
  File "/opt/conda/lib/python3.10/site-packages/paddle/nn/layer/layers.py", line 1429, in __call__
    return self.forward(*inputs, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/transformers/ernie/modeling.py", line 709, in forward
    outputs = self.ernie(
  File "/opt/conda/lib/python3.10/site-packages/paddle/nn/layer/layers.py", line 1429, in __call__
    return self.forward(*inputs, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/trainer/trainer_compress.py", line 907, in auto_model_dynabert_forward
    embedding_output = self.embeddings(**embedding_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/paddle/nn/layer/layers.py", line 1429, in __call__
    return self.forward(*inputs, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/paddlenlp/transformers/ernie/modeling.py", line 127, in forward
    embeddings = self.layer_norm(embeddings)
  File "/opt/conda/lib/python3.10/site-packages/paddle/nn/layer/layers.py", line 1429, in __call__
    return self.forward(*inputs, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/paddleslim/nas/ofa/layers.py", line 1301, in forward
    out, _, _ = paddle._C_ops.layer_norm(
ValueError: too many values to unpack (expected 3)

排查后发现是与paddle库的更改未统一。